### PR TITLE
RM-36522: Implemented rule use_isinf_to_check_for_infinite

### DIFF
--- a/checks/check_use_isinf_to_check_for_infinite.jl
+++ b/checks/check_use_isinf_to_check_for_infinite.jl
@@ -1,0 +1,49 @@
+module UseIsinfToCheckForInfinite
+
+import JuliaSyntax: SyntaxNode, GreenNode, @K_str, @KSet_str, children, kind,
+                numchildren, span, untokenize
+using ...Properties: NullableString, find_first_of_kind, get_assignee,
+                haschildren, report_violation
+
+"""
+    check(node::SyntaxNode)
+
+Check if a check for infinity is done by direct comparison.
+"""
+function check(node::SyntaxNode)::Nothing
+    inf_type = extract_inf_type(node)
+    if inf_type !== nothing
+        report_violation(node;
+            severity=3, rule_id="asml-use-isinf-to-check-for-infinite",
+            user_msg = "Detected comparison with $inf_type.",
+            summary = "Use isinf to check for infinite values.")
+    end
+end
+
+function extract_inf_type(node::SyntaxNode)::NullableString
+    sign = ""
+    if kind(node) == K"call" && numchildren(node) > 1
+        first, second = children(node)[1:2]
+        if kind(first) == K"Identifier" && string(first) ∈ ("-", "+")
+            if string(first) == "-" sign = "-" end
+            node = second
+        end
+    end
+
+    if kind(node) == K"." && length(children(node)) >= 2
+        # For qualified names like Base.Inf, return just the Inf part
+        node = last(children(node))
+    end
+
+    if kind(node) == K"Identifier"
+        value = string(node)
+        if value ∈ ("Inf", "Inf16", "Inf32", "Inf64")
+            return sign * value
+        end
+    end
+
+    return nothing
+end
+
+
+end # module UseIsinfToCheckForInfinite

--- a/src/Checks.jl
+++ b/src/Checks.jl
@@ -24,5 +24,6 @@ include("../checks/check_struct_members_are_in_lower_snake_case.jl")
 include("../checks/check_too_many_types_in_unions.jl")
 include("../checks/check_type_names_upper_camel_case.jl")
 include("../checks/check_use_spaces_instead_of_tabs.jl")
+include("../checks/check_use_isinf_to_check_for_infinite.jl")
 
 end

--- a/src/Process.jl
+++ b/src/Process.jl
@@ -1,7 +1,8 @@
 module Process
 
 import JuliaSyntax: GreenNode, SyntaxNode, SourceFile, ParseError, @K_str,
-    children, is_whitespace, kind, span, untokenize, JuliaSyntax as JS
+    children, is_whitespace, kind, numchildren, span, untokenize,
+    JuliaSyntax as JS
 
 # include("SymbolTable.jl")
 # import .SymbolTable
@@ -109,6 +110,14 @@ function process_operator(node::AnyTree)
         #Checks.SpaceAroundInfixOperators.check(node)
 
         if is_assignment(node) process_assignment(node) end
+        if is_eq_comparison(node)
+            if numchildren(node) != 3
+                @debug "A comparison with a number of children != 3" node
+            else
+                lhs, _, rhs = children(node)
+                Checks.UseIsinfToCheckForInfinite.check.([lhs, rhs])
+            end
+        end
 
     elseif JS.is_postfix_op_call(node)
         # something with postfix operators

--- a/tests/use_isinf_to_check_for_infinite.jl
+++ b/tests/use_isinf_to_check_for_infinite.jl
@@ -1,0 +1,6 @@
+my_is_inf(value) = value == Inf || value == -Inf
+missing_case(value) = (value == +Inf) != isinf(value)
+good_is_inf(value) = isinf(value)
+function is_inf_any_size(value)
+    return value == Base.Inf16 || value == -Base.Inf32 || value == Base.Inf64
+end

--- a/tests/use_isinf_to_check_for_infinite.val
+++ b/tests/use_isinf_to_check_for_infinite.val
@@ -1,0 +1,39 @@
+
+>> Processing file 'tests/use_isinf_to_check_for_infinite.jl'...
+
+tests/use_isinf_to_check_for_infinite.jl(1, 29):
+my_is_inf(value) = value == Inf || value == -Inf
+#                           └─┘ ── Detected comparison with Inf.
+Use isinf to check for infinite values.
+Rule: asml-use-isinf-to-check-for-infinite. Severity: 3
+
+tests/use_isinf_to_check_for_infinite.jl(1, 44):
+my_is_inf(value) = value == Inf || value == -Inf
+#                                          └───┘ ── Detected comparison with -Inf.
+Use isinf to check for infinite values.
+Rule: asml-use-isinf-to-check-for-infinite. Severity: 3
+
+tests/use_isinf_to_check_for_infinite.jl(2, 32):
+missing_case(value) = (value == +Inf) != isinf(value)
+#                              └───┘ ── Detected comparison with Inf.
+Use isinf to check for infinite values.
+Rule: asml-use-isinf-to-check-for-infinite. Severity: 3
+
+tests/use_isinf_to_check_for_infinite.jl(5, 21):
+    return value == Base.Inf16 || value == -Base.Inf32 || value == Base.Inf64
+#                   └────────┘ ── Detected comparison with Inf16.
+Use isinf to check for infinite values.
+Rule: asml-use-isinf-to-check-for-infinite. Severity: 3
+
+tests/use_isinf_to_check_for_infinite.jl(5, 43):
+    return value == Base.Inf16 || value == -Base.Inf32 || value == Base.Inf64
+#                                         └──────────┘ ── Detected comparison with -Inf32.
+Use isinf to check for infinite values.
+Rule: asml-use-isinf-to-check-for-infinite. Severity: 3
+
+tests/use_isinf_to_check_for_infinite.jl(5, 68):
+    return value == Base.Inf16 || value == -Base.Inf32 || value == Base.Inf64
+#                                                                  └────────┘ ── Detected comparison with Inf64.
+Use isinf to check for infinite values.
+Rule: asml-use-isinf-to-check-for-infinite. Severity: 3
+


### PR DESCRIPTION
I have also restricted the type of all predicates (`is_...(node)`) to `Bool` after realizing it could be error-prone if not done.