### PR TITLE
RM-36541: Added inequality comparisons to tests

### DIFF
--- a/tests/use_isinf_to_check_for_infinite.jl
+++ b/tests/use_isinf_to_check_for_infinite.jl
@@ -1,6 +1,6 @@
 my_is_inf(value) = value == Inf || value == -Inf
 missing_case(value) = (value == +Inf) != isinf(value)
 good_is_inf(value) = isinf(value)
-function is_inf_any_size(value)
-    return value == Base.Inf16 || value == -Base.Inf32 || value == Base.Inf64
+function is_not_inf_any_size(value)
+    return value != Base.Inf16 || value != -Base.Inf32 || value != Base.Inf64
 end

--- a/tests/use_isinf_to_check_for_infinite.val
+++ b/tests/use_isinf_to_check_for_infinite.val
@@ -20,19 +20,19 @@ Use isinf to check for infinite values.
 Rule: asml-use-isinf-to-check-for-infinite. Severity: 3
 
 tests/use_isinf_to_check_for_infinite.jl(5, 21):
-    return value == Base.Inf16 || value == -Base.Inf32 || value == Base.Inf64
+    return value != Base.Inf16 || value != -Base.Inf32 || value != Base.Inf64
 #                   └────────┘ ── Detected comparison with Inf16.
 Use isinf to check for infinite values.
 Rule: asml-use-isinf-to-check-for-infinite. Severity: 3
 
 tests/use_isinf_to_check_for_infinite.jl(5, 43):
-    return value == Base.Inf16 || value == -Base.Inf32 || value == Base.Inf64
+    return value != Base.Inf16 || value != -Base.Inf32 || value != Base.Inf64
 #                                         └──────────┘ ── Detected comparison with -Inf32.
 Use isinf to check for infinite values.
 Rule: asml-use-isinf-to-check-for-infinite. Severity: 3
 
 tests/use_isinf_to_check_for_infinite.jl(5, 68):
-    return value == Base.Inf16 || value == -Base.Inf32 || value == Base.Inf64
+    return value != Base.Inf16 || value != -Base.Inf32 || value != Base.Inf64
 #                                                                  └────────┘ ── Detected comparison with Inf64.
 Use isinf to check for infinite values.
 Rule: asml-use-isinf-to-check-for-infinite. Severity: 3

--- a/tests/use_ismissing_to_check_for_missing_values.jl
+++ b/tests/use_ismissing_to_check_for_missing_values.jl
@@ -1,2 +1,3 @@
 my_is_missing(value) = value == missing || typeof(value) == Missing
+my_not_missing(value) = value != missing || typeof(value) != Missing
 good_is_missing(value) = ismissing(value)

--- a/tests/use_ismissing_to_check_for_missing_values.val
+++ b/tests/use_ismissing_to_check_for_missing_values.val
@@ -13,3 +13,15 @@ my_is_missing(value) = value == missing || typeof(value) == Missing
 Use ismissing to check for missing values.
 Rule: asml-use-ismissing-to-check-for-missing-values. Severity: 3
 
+tests/use_ismissing_to_check_for_missing_values.jl(2, 34):
+my_not_missing(value) = value != missing || typeof(value) != Missing
+#                                └─────┘ ── Detected comparison with missing.
+Use ismissing to check for missing values.
+Rule: asml-use-ismissing-to-check-for-missing-values. Severity: 3
+
+tests/use_ismissing_to_check_for_missing_values.jl(2, 62):
+my_not_missing(value) = value != missing || typeof(value) != Missing
+#                                                            └─────┘ ── Detected comparison with Missing.
+Use ismissing to check for missing values.
+Rule: asml-use-ismissing-to-check-for-missing-values. Severity: 3
+

--- a/tests/use_isnan_to_check_for_nan.jl
+++ b/tests/use_isnan_to_check_for_nan.jl
@@ -1,5 +1,5 @@
 my_is_nan(value) = value != value || value == NaN || value === NaN
 good_is_nan(value) = isnan(value)
-function is_nan_any_size(value)
-    return value == Base.NaN16 || value == -Base.NaN32 || value == Base.NaN64
+function is_not_nan_any_size(value)
+    return value != Base.NaN16 || value != -Base.NaN32 || value != Base.NaN64
 end

--- a/tests/use_isnan_to_check_for_nan.val
+++ b/tests/use_isnan_to_check_for_nan.val
@@ -14,19 +14,19 @@ Use isnan to check for not-a-number values.
 Rule: asml-use-isnan-to-check-for-nan. Severity: 3
 
 tests/use_isnan_to_check_for_nan.jl(4, 21):
-    return value == Base.NaN16 || value == -Base.NaN32 || value == Base.NaN64
+    return value != Base.NaN16 || value != -Base.NaN32 || value != Base.NaN64
 #                   └────────┘ ── Detected comparison with NaN16.
 Use isnan to check for not-a-number values.
 Rule: asml-use-isnan-to-check-for-nan. Severity: 3
 
 tests/use_isnan_to_check_for_nan.jl(4, 43):
-    return value == Base.NaN16 || value == -Base.NaN32 || value == Base.NaN64
+    return value != Base.NaN16 || value != -Base.NaN32 || value != Base.NaN64
 #                                         └──────────┘ ── Detected comparison with -NaN32.
 Use isnan to check for not-a-number values.
 Rule: asml-use-isnan-to-check-for-nan. Severity: 3
 
 tests/use_isnan_to_check_for_nan.jl(4, 68):
-    return value == Base.NaN16 || value == -Base.NaN32 || value == Base.NaN64
+    return value != Base.NaN16 || value != -Base.NaN32 || value != Base.NaN64
 #                                                                  └────────┘ ── Detected comparison with NaN64.
 Use isnan to check for not-a-number values.
 Rule: asml-use-isnan-to-check-for-nan. Severity: 3


### PR DESCRIPTION
This was agreed with ASML. They missed inequality examples in their "bad style" examples.