### PR TITLE
Normalize line endings for tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
-# These files should always be checked out with OS line endings (simulated cmdline output)
-*.val text=auto
+# Check out val files with lf, actual output EOL will be converted in tests for Windows
+*.val text eol=lf
 
 # Fix syntax highlighting on GitHub to allow comments
 .vscode/*.json linguist-language=JSON-with-Comments

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 # Auto detect text files and perform LF normalization
-*          text=auto
+* text=auto
 
-# These file should always be checked out with OS line endings (simulated cmdline output)
-*.val text
+# These files should always be checked out with OS line endings (simulated cmdline output)
+*.val text=auto
 
 # Fix syntax highlighting on GitHub to allow comments
 .vscode/*.json linguist-language=JSON-with-Comments

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,7 +148,7 @@ end
             result = IOCapture.capture() do
                 JuliaCheck.main(["--enable", corresponding_rule, "--", in_file])
             end
-            @test chomp(result.output) == expected
+            @test replace(chomp(result.output), "\r\n" => "\n") == expected
         end
     end
 end


### PR DESCRIPTION
This caused all tests to fail on Windows (depending on how the .val files are checked out)