### PR TITLE
Put check discovery back on top-level

### DIFF
--- a/src/JuliaCheck.jl
+++ b/src/JuliaCheck.jl
@@ -15,10 +15,7 @@ include("WhitespaceHelpers.jl")
 using .Analysis
 using .ViolationPrinters
 
-function __init__()
-    Analysis.discover_checks()
-end
-
+Analysis.discover_checks()
 
 function parse_commandline(args::Vector{String})
     s = ArgParseSettings(


### PR DESCRIPTION
This fixes the issue that running in a non-REPL context the checks are not discovered, resulting in an 'Unknown rules' error.

It was moved to the `__init__` function to ensure the latest rules are discovered, but this caused the above problem.