### PR TITLE
Mark contents of 'checks' directory as compilation dependency

### DIFF
--- a/src/Analysis.jl
+++ b/src/Analysis.jl
@@ -210,7 +210,9 @@ end
 
 "Load all check modules in checks directory."
 function discover_checks()::Nothing
-    for file in filter(f -> endswith(f, ".jl"), readdir(joinpath(@__DIR__, "..", "checks"), join=true))
+    checks_path = joinpath(@__DIR__, "..", "checks")
+    include_dependency(checks_path) # Mark directory contents as precompilation dependency
+    for file in filter(f -> endswith(f, ".jl"), readdir(checks_path, join=true))
         try
             include(file)
         catch exception


### PR DESCRIPTION
Due to the dynamic import, adding files to the 'checks' dir did not result in a recompilation of the module, meaning new rules were not picked up. This resulted in test failures.

Using `include_dependency` on the 'checks' dir marks the directory contents as a compilation dependency. This means the module is marked for recompilation if the contents of 'checks' have changed since the last compilation.