### PR TITLE
RM-37007: Implement rule IndentationOfModules

### DIFF
--- a/checks/IndentationOfModules.jl
+++ b/checks/IndentationOfModules.jl
@@ -3,10 +3,10 @@ module IndentationOfModules
 using Base: indent_width, _ind2sub
 include("_common.jl")
 
+using JuliaSyntax: view
 using ...Properties: is_module, get_module_name
 using ...SyntaxNodeHelpers: ancestors
 using ...WhitespaceHelpers: normalized_green_child_range
-using JuliaSyntax: GreenNode, source_location, is_whitespace, first_byte, last_byte, byte_range, view
 
 struct Check<:Analysis.Check end
 id(::Check) = "indentation-of-modules"
@@ -34,17 +34,13 @@ function _check(this::Check, ctxt::AnalysisContext, module_node::SyntaxNode)::No
         if !isnothing(prev_sibling) && kind(prev_sibling) == K"NewlineWs" # Previous node is indent
             ws_range = normalized_green_child_range(mod_contents_node, prev_i)
             actual_indent = length(strip(view(module_node.source, ws_range), ['\r', '\n'])) # Only report on indent on current line (not newlines)
+
             if exp_indent != actual_indent
                 nudged_range = range(;stop=ws_range.stop, length=actual_indent)
                 report_violation(ctxt, this, nudged_range, "Contents of module '$module_name' should have an indentation of width $exp_indent, but found $actual_indent")
             end
         end
     end
-end
-
-function _indent_width(ws_node::GreenNode)::Int
-    start_column = source_location(ws_node)[2]
-    return start_column - 1
 end
 
 end # module IndentationOfModules

--- a/checks/IndentationOfModules.jl
+++ b/checks/IndentationOfModules.jl
@@ -1,0 +1,50 @@
+module IndentationOfModules
+
+using Base: indent_width, _ind2sub
+include("_common.jl")
+
+using ...Properties: is_module, get_module_name
+using ...SyntaxNodeHelpers: ancestors
+using ...WhitespaceHelpers: normalized_green_child_range
+using JuliaSyntax: GreenNode, source_location, is_whitespace, first_byte, last_byte, byte_range, view
+
+struct Check<:Analysis.Check end
+id(::Check) = "indentation-of-modules"
+severity(::Check) = 7
+synopsis(::Check) = "Do not indent top level module body, do indent submodules"
+
+function init(this::Check, ctxt::AnalysisContext)
+    register_syntaxnode_action(ctxt, is_module, n -> _check(this, ctxt, n))
+end
+
+function _check(this::Check, ctxt::AnalysisContext, module_node::SyntaxNode)::Nothing
+    module_nest_level = count(is_module, ancestors(module_node; include_self=false))
+    exp_indent = 4 * module_nest_level
+    (_, module_name) = get_module_name(module_node)
+
+    mod_contents_node = children(module_node)[2]
+    for content_node in children(mod_contents_node)
+        green_children = children(mod_contents_node.raw)
+        green_node = content_node.raw
+        green_idx = first(indexin([green_node], green_children))
+
+        prev_i = prevind(green_children, green_idx)
+        prev_sibling = checkbounds(Bool, green_children, prev_i) ? green_children[prev_i] : nothing
+
+        if !isnothing(prev_sibling) && kind(prev_sibling) == K"NewlineWs" # Previous node is indent
+            ws_range = normalized_green_child_range(mod_contents_node, prev_i)
+            actual_indent = length(strip(view(module_node.source, ws_range), ['\r', '\n'])) # Only report on indent on current line (not newlines)
+            if exp_indent != actual_indent
+                nudged_range = range(;stop=ws_range.stop, length=actual_indent)
+                report_violation(ctxt, this, nudged_range, "Contents of module '$module_name' should have an indentation of width $exp_indent, but found $actual_indent")
+            end
+        end
+    end
+end
+
+function _indent_width(ws_node::GreenNode)::Int
+    start_column = source_location(ws_node)[2]
+    return start_column - 1
+end
+
+end # module IndentationOfModules

--- a/checks/IndentationOfModules.jl
+++ b/checks/IndentationOfModules.jl
@@ -1,6 +1,5 @@
 module IndentationOfModules
 
-using Base: indent_width, _ind2sub
 include("_common.jl")
 
 using JuliaSyntax: view
@@ -13,8 +12,9 @@ id(::Check) = "indentation-of-modules"
 severity(::Check) = 7
 synopsis(::Check) = "Do not indent top level module body, do indent submodules"
 
-function init(this::Check, ctxt::AnalysisContext)
+function init(this::Check, ctxt::AnalysisContext)::Nothing
     register_syntaxnode_action(ctxt, is_module, n -> _check(this, ctxt, n))
+    return nothing
 end
 
 function _check(this::Check, ctxt::AnalysisContext, module_node::SyntaxNode)::Nothing

--- a/src/CommentHelpers.jl
+++ b/src/CommentHelpers.jl
@@ -1,7 +1,7 @@
 module CommentHelpers
 
 using JuliaSyntax: @K_str, @KSet_str, SyntaxNode, kind, child_position_span, view, JuliaSyntax as JS
-using ..WhitespaceHelpers: combine_ranges, normalized_child_position_span
+using ..WhitespaceHelpers: combine_ranges, normalized_green_child_range
 
 export Comment, CommentBlock, get_comment_blocks, get_range, get_text, contains_comments
 
@@ -34,7 +34,7 @@ function get_comment_blocks(sn::SyntaxNode)::Vector{CommentBlock}
     # if there is only whitespace between them
     for (i, ch) in enumerate(green_children)
         if kind(ch) == K"Comment"
-            range = normalized_child_position_span(sn, sn.raw, i)
+            range = normalized_green_child_range(sn, i)
             push!(curblock, Comment(range, JS.view(sn.source, range)))
         elseif kind(ch) ∈ KSet"Whitespace NewlineWs"
             continue # Whitespace does not interrupt comment block

--- a/src/WhitespaceHelpers.jl
+++ b/src/WhitespaceHelpers.jl
@@ -102,12 +102,12 @@ function normalize_range(base_node::SyntaxNode, relative_range::UnitRange)::Unit
 end
 
 """
-Get the normalized range of the GreenNode at descendant path `path` from the GreenNode corresponding to `SyntaxNode`
+Get the normalized range of the GreenNode at descendant path `path` from the GreenNode corresponding to SyntaxNode `sn`
 
 See `JuliaSyntax.child_position_span(::GreenNode, ::Int..)`
 """
-function normalized_child_position_span(sn::SyntaxNode, gn::GreenNode, path::Int...)::UnitRange{Int}
-    _, p, span = child_position_span(gn, path...)
+function normalized_green_child_range(sn::SyntaxNode, path::Int...)::UnitRange{Int}
+    _, p, span = child_position_span(sn.raw, path...)
     range = p:p + span - 1
     return normalize_range(sn, range)
 end

--- a/test/res/IndentationOfModules.jl
+++ b/test/res/IndentationOfModules.jl
@@ -1,0 +1,50 @@
+module GoodTopLevelModule
+include("Properties.jl"); import .Properties
+
+    bad_function() = false
+
+function good_function()
+    return true
+end
+    module BadStyle
+        import Statistics
+
+        export bar, foo
+
+        foo()::Nothing = nothing
+        bar()::String = "the bar is open " *
+                "and closes at 10"
+    end # module BadStyle
+
+module GoodStyle
+    import Statistics
+
+    include("SomeOtherSubModule.jl")
+    using .SomeOtherSubModule
+
+    include("SomeSubmodule.jl")
+    using .SomeSubmodule
+
+module BadNestedModule
+                    module WayOffModule
+
+                    end
+end
+
+    module GoodNestedModule
+
+    module BadDoubleNestedModule
+
+    end
+
+    end
+
+    export foo
+    export bar
+
+    foo()::Nothing = nothing
+    bar()::String = "the bar is open"
+
+end # module GoodStyle
+
+end # module GoodTopLevelModule

--- a/test/res/IndentationOfModules.val
+++ b/test/res/IndentationOfModules.val
@@ -1,0 +1,55 @@
+>> Processing file 'IndentationOfModules.jl'...
+
+IndentationOfModules.jl(4, 1):
+    bad_function() = false
+└──┘ ── Contents of module 'GoodTopLevelModule' should have an indentation of width 0, but found 4.
+Do not indent top level module body, do indent submodules.
+Rule: indentation-of-modules. Severity: 7
+
+IndentationOfModules.jl(9, 1):
+    module BadStyle
+└──┘ ── Contents of module 'GoodTopLevelModule' should have an indentation of width 0, but found 4.
+Do not indent top level module body, do indent submodules.
+Rule: indentation-of-modules. Severity: 7
+
+IndentationOfModules.jl(10, 1):
+        import Statistics
+└──────┘ ── Contents of module 'BadStyle' should have an indentation of width 4, but found 8.
+Do not indent top level module body, do indent submodules.
+Rule: indentation-of-modules. Severity: 7
+
+IndentationOfModules.jl(12, 1):
+        export bar, foo
+└──────┘ ── Contents of module 'BadStyle' should have an indentation of width 4, but found 8.
+Do not indent top level module body, do indent submodules.
+Rule: indentation-of-modules. Severity: 7
+
+IndentationOfModules.jl(14, 1):
+        foo()::Nothing = nothing
+└──────┘ ── Contents of module 'BadStyle' should have an indentation of width 4, but found 8.
+Do not indent top level module body, do indent submodules.
+Rule: indentation-of-modules. Severity: 7
+
+IndentationOfModules.jl(15, 1):
+        bar()::String = "the bar is open " *
+└──────┘ ── Contents of module 'BadStyle' should have an indentation of width 4, but found 8.
+Do not indent top level module body, do indent submodules.
+Rule: indentation-of-modules. Severity: 7
+
+IndentationOfModules.jl(28, 1):
+module BadNestedModule
+└ ── Contents of module 'GoodStyle' should have an indentation of width 4, but found 0.
+Do not indent top level module body, do indent submodules.
+Rule: indentation-of-modules. Severity: 7
+
+IndentationOfModules.jl(29, 1):
+                    module WayOffModule
+└──────────────────┘ ── Contents of module 'BadNestedModule' should have an indentation of width 8, but found 20.
+Do not indent top level module body, do indent submodules.
+Rule: indentation-of-modules. Severity: 7
+
+IndentationOfModules.jl(36, 1):
+    module BadDoubleNestedModule
+└──┘ ── Contents of module 'GoodNestedModule' should have an indentation of width 8, but found 4.
+Do not indent top level module body, do indent submodules.
+Rule: indentation-of-modules. Severity: 7


### PR DESCRIPTION
Note that despite what the rule name implies, this concerns the indentation of all _contents_ of the module body, not just nested modules themselves. Thus, this checks the indent of all top-level children of a module, e.g. functions, expressions, nested modules, etc.

## CS rule:

### Do not indent top level module body, do indent submodules
Rule id: indentation-of-modules \
Severity: 7 \
User message: Modules spanning a file in full are not indented but all other modules are.

When writing a module that is at the top level in a file do not indent the body of this module. Doing this would merely result in almost all lines of the file being indented one level more and consumes needless horizontal space while contributing little to readability. Submodules below the top level module need to be indented by one level more than the module they are contained in.

JuliaFormatter setting: [`indent_submodule`](https://domluna.github.io/JuliaFormatter.jl/stable/#indent_submodule), set to `true`.

> Rationale: readability

```Julia
# Bad style:
module A
    function f(x)
        return x^2
    end

    module B
        function g(x)
            return x + 2
        end
    end
end

# Good style:
module A
function f(x)
    return x^2
end

module B
    function g(x)
        return x + 2
    end
end
end