### PR TITLE
RM-37938: Fix macro body being considered global scope

### DIFF
--- a/src/Properties.jl
+++ b/src/Properties.jl
@@ -18,7 +18,7 @@ export AnyTree, NullableNode, MAX_LINE_LENGTH,
     haschildren, increase_counters, is_abstract, is_array_assignment, is_array_indx, is_assignment,
     is_broadcasting_assignment, is_constant, is_dot, is_eq_neq_comparison, is_eval_call, is_export,
     is_fat_snake_case, is_field_assignment, is_flow_cntrl, is_function, is_global_decl,
-    is_import, is_include, is_infix_operator, is_literal_number, is_loop, is_lower_snake,
+    is_import, is_include, is_infix_operator, is_literal_number, is_loop, is_lower_snake, is_macro,
     is_module, is_mutating_call, is_operator, is_range, is_separator, is_stop_point,
     is_struct, is_toplevel, is_type_op, is_union_decl, is_upper_camel_case, is_vect,
     is_call, is_mod_toplevel, inside,
@@ -70,6 +70,7 @@ is_assignment(node::AnyTree)::Bool = kind(node) == K"=" &&
     kind(node.parent) ∉ KSet"parameters tuple" # Do not consider keyword arguments an assignment
 is_dot(node::AnyTree)::Bool = kind(node) == K"."
 is_function(node::AnyTree)::Bool = kind(node) == K"function"
+is_macro(node::AnyTree)::Bool = kind(node) == K"macro"
 is_struct(node::AnyTree)::Bool = kind(node) == K"struct"
 is_abstract(node::AnyTree)::Bool = kind(node) == K"abstract"
 is_array_indx(node::AnyTree)::Bool = kind(node) == K"ref"
@@ -184,7 +185,7 @@ end
 Return the node carrying the function's name.
 """
 function get_func_name(node::SyntaxNode)::NullableNode
-    @assert is_function(node) "Expected a [function] node, got [$(kind(node))]."
+    @assert (is_function(node) || is_macro(node)) "Expected a [function] or [macro] node, got [$(kind(node))]."
     fname = find_lhs_of_kind(K"Identifier", node)
     if isnothing(fname)
         # We give it one more chance to find the function's name: it will return
@@ -218,7 +219,7 @@ end
 Return a list of nodes representing the arguments of a function.
 """
 function get_func_arguments(node::SyntaxNode)::Vector{SyntaxNode}
-    @assert is_function(node) "Expected a [function] node, got [$(kind(node))]."
+    @assert (is_function(node) || is_macro(node)) "Expected a [function] or [macro] node, got [$(kind(node))]."
     call = find_lhs_of_kind(K"call", children(node)[1])
     if isnothing(call)
         # Probably a function "stub", which declares a function name but no methods.

--- a/src/SymbolTable.jl
+++ b/src/SymbolTable.jl
@@ -4,7 +4,7 @@ import DataStructures: Stack
 
 using JuliaSyntax: SyntaxNode, @K_str, children, head, kind, sourcetext
 using ..Properties: find_lhs_of_kind, get_func_name, get_assignee, get_func_arguments,
-    get_module_name, get_var_from_assignment, haschildren, is_assignment, is_function,
+    get_module_name, get_var_from_assignment, haschildren, is_assignment, is_function, is_macro,
     is_global_decl, is_module, opens_scope, is_mod_toplevel
 using ..SyntaxNodeHelpers: ancestors, find_descendants, get_all_assignees
 using ..TypeHelpers: get_variable_type_from_node, is_different_type, TypeSpecifier
@@ -234,7 +234,7 @@ Currently logs new modules, functions, and (global) variables.
 function update_symbol_table_on_node_enter!(table::SymbolTableStruct, node::SyntaxNode)::Nothing
     if is_module(node)
         _enter_module!(table, node)
-    elseif is_function(node)
+    elseif is_function(node) || is_macro(node)
         _process_function!(table, node)
     elseif is_global_decl(node)
         _process_global!(table, node)

--- a/test/res/GlobalVariablesUpperSnakeCase.jl
+++ b/test/res/GlobalVariablesUpperSnakeCase.jl
@@ -36,3 +36,8 @@ dict["a"] = "b" # Good: `dict` is not declared here
 
 # RM-37326, note 7: do not report on same global variable twice
 some_number, another_number, yet_another_number = 3, 1, 1 # Bad: yet_another_number
+
+# RM-37938: do not report inside macro body
+macro mymacro(expr::Expr)
+    some_name = "a"
+end


### PR DESCRIPTION
See RM-37938.

Variables inside a macro body were considered global, causing false positives of `global-variables-upper-snake-case`.

Now handling macro definitions identically to functions in the symbol table, so macro bodies are added to the scope stack.