### PR TITLE
RM-37939: Consider struct definitions non-global

### DIFF
--- a/src/Properties.jl
+++ b/src/Properties.jl
@@ -171,8 +171,7 @@ end
 
 function opens_scope(node::SyntaxNode)
     return is_function(node) ||
-            kind(node) ∈ [KSet"for while try do let macro generator"]
-                                # comprehensions contain a generator
+            kind(node) ∈ KSet"for while try do let macro generator struct"
 end
 function closes_scope(node::SyntaxNode)
     return kind(node) == K"end" && opens_scope(node.parent)

--- a/src/SymbolTable.jl
+++ b/src/SymbolTable.jl
@@ -243,6 +243,8 @@ function update_symbol_table_on_node_enter!(table::SymbolTableStruct, node::Synt
             is_mod_toplevel(node.parent) # Top-level assignment defines a global variable
         scope = is_assignment_to_global ? _global_scope(table) : _current_scope(table)
         _process_assignment!(scope, node)
+    elseif opens_scope(node)
+        _enter_scope!(table)
     end
     return nothing
 end

--- a/test/res/GlobalVariablesUpperSnakeCase.jl
+++ b/test/res/GlobalVariablesUpperSnakeCase.jl
@@ -41,3 +41,10 @@ some_number, another_number, yet_another_number = 3, 1, 1 # Bad: yet_another_num
 macro mymacro(expr::Expr)
     some_name = "a"
 end
+
+# RM-37939: do not report inside struct definition
+Base.@kwdef struct NiceStruct
+    my_bool = true
+end
+
+some_number_also = 1 # Bad: put violation at end to check scopes are exited properly

--- a/test/res/GlobalVariablesUpperSnakeCase.val
+++ b/test/res/GlobalVariablesUpperSnakeCase.val
@@ -35,3 +35,9 @@ some_number, another_number, yet_another_number = 3, 1, 1 # Bad: yet_another_num
 #                            └────────────────┘ ── Variable 'yet_another_number' should be written in UPPER_SNAKE_CASE.
 Casing of globals.
 Rule: global-variables-upper-snake-case. Severity: 3
+
+GlobalVariablesUpperSnakeCase.jl(50, 1):
+some_number_also = 1 # Bad: put violation at end to check scopes are exited properly
+└──────────────┘ ── Variable 'some_number_also' should be written in UPPER_SNAKE_CASE.
+Casing of globals.
+Rule: global-variables-upper-snake-case. Severity: 3


### PR DESCRIPTION
See RM-37939.

Struct definition bodies should not be considered part of the global scope. This PR adds `struct` to the set of node kinds that enter a scope in the SymbolTable.

* Kind check in properties.jl failed due to KSet nested in a vector. Removed vector and added `struct` to the list of 'scope kinds'.
  * This also fixes an issue where the 'macro' scope was not exited properly, causing global variables declared after the macro to be considered part of the macro's scope. 
* Call `_enter_scope!` on nodes matching opens_scope, to match how scope is already exited when leaving such nodes
