### PR TITLE
RM-37940: Added clarifying message to AvoidHardCodedNumbers.

### DIFF
--- a/checks/AvoidHardCodedNumbers.jl
+++ b/checks/AvoidHardCodedNumbers.jl
@@ -1,5 +1,7 @@
 module AvoidHardCodedNumbers
 
+import JuliaSyntax: sourcetext
+
 using ...Properties: get_number, is_constant, is_global_decl, is_literal_number
 
 include("_common.jl")
@@ -31,11 +33,11 @@ const KNOWN_FLOATS = Set{Float64}([0.1, 0.01, 0.001, 0.0001, 0.5]) ∪
                     Set{Float64}(convert.(Float64, SOME_SPECIAL_INTS))
 
 struct Check<:Analysis.Check
-    number_occurrence::Dict{Number, Vector{SyntaxNode}}
+    number_occurrence::Dict{Number, SyntaxNode}
 
     # FIXME Fine for integers but, for floats, we should
     # probably use a tolerance to compare them.
-    Check() = new(Dict{Number, Vector{SyntaxNode}}())
+    Check() = new(Dict{Number, SyntaxNode}())
 end
 Analysis.id(::Check) = "avoid-hard-coded-numbers"
 Analysis.severity(::Check) = 3
@@ -52,14 +54,13 @@ function _check(this::Check, ctxt::AnalysisContext, node::SyntaxNode)::Nothing
     if !_is_const_declaration(node) && !_in_array_assignment(node) && _is_magic_number(node)
         n = get_number(node)
         if !haskey(this.number_occurrence, n)
-            this.number_occurrence[n] = Vector{SyntaxNode}()
-        end
-        push!(this.number_occurrence[n], node)
-        if length(this.number_occurrence[n]) > 1
-            first_instance_line, _ = source_location(first(this.number_occurrence[n]))
+            this.number_occurrence[n] = node
+        else
+            first_instance_line, _ = source_location(this.number_occurrence[n])
             current_instance_line, _ = source_location(node)
+            number_text = sourcetext(node)
             extra_msg = first_instance_line == current_instance_line ? "earlier on the same line" : "at line $first_instance_line"
-            report_violation(ctxt, this, node, "Hard-coded number '$n' (first used $extra_msg) should be a const variable.")
+            report_violation(ctxt, this, node, "Hard-coded number '$number_text' (first used $extra_msg) should be a const variable.")
         end
     end
     return nothing

--- a/checks/AvoidHardCodedNumbers.jl
+++ b/checks/AvoidHardCodedNumbers.jl
@@ -52,13 +52,13 @@ function _check(this::Check, ctxt::AnalysisContext, node::SyntaxNode)::Nothing
     if !_is_const_declaration(node) && !_in_array_assignment(node) && _is_magic_number(node)
         n = get_number(node)
         if haskey(this.seen_before, n)
-            previous_line = this.seen_before[n]
+            first_seen_line = this.seen_before[n]
             current_line, _ = source_location(node)
-            extra_msg = previous_line == current_line ? "earlier on the same line" : "at line $previous_line"
+            extra_msg = first_seen_line == current_line ? "earlier on the same line" : "at line $previous_line"
             report_violation(ctxt, this, node, "Hard-coded number '$n' (first used $extra_msg) should be a const variable.")
         else
-            line, _ = source_location(node)
-            this.seen_before[n] = line
+            first_seen_line, _ = source_location(node)
+            this.seen_before[n] = first_seen_line
         end
     end
     return nothing

--- a/checks/AvoidHardCodedNumbers.jl
+++ b/checks/AvoidHardCodedNumbers.jl
@@ -54,7 +54,7 @@ function _check(this::Check, ctxt::AnalysisContext, node::SyntaxNode)::Nothing
         if haskey(this.seen_before, n)
             first_seen_line = this.seen_before[n]
             current_line, _ = source_location(node)
-            extra_msg = first_seen_line == current_line ? "earlier on the same line" : "at line $previous_line"
+            extra_msg = first_seen_line == current_line ? "earlier on the same line" : "at line $first_seen_line"
             report_violation(ctxt, this, node, "Hard-coded number '$n' (first used $extra_msg) should be a const variable.")
         else
             first_seen_line, _ = source_location(node)

--- a/checks/AvoidHardCodedNumbers.jl
+++ b/checks/AvoidHardCodedNumbers.jl
@@ -31,11 +31,11 @@ const KNOWN_FLOATS = Set{Float64}([0.1, 0.01, 0.001, 0.0001, 0.5]) ∪
                     Set{Float64}(convert.(Float64, SOME_SPECIAL_INTS))
 
 struct Check<:Analysis.Check
-    seen_before::Dict{Number, Integer}
+    number_occurrence::Dict{Number, Vector{SyntaxNode}}
 
     # FIXME Fine for integers but, for floats, we should
     # probably use a tolerance to compare them.
-    Check() = new(Dict{Number, Integer}())
+    Check() = new(Dict{Number, Vector{SyntaxNode}}())
 end
 Analysis.id(::Check) = "avoid-hard-coded-numbers"
 Analysis.severity(::Check) = 3
@@ -51,14 +51,15 @@ function _check(this::Check, ctxt::AnalysisContext, node::SyntaxNode)::Nothing
     @assert is_literal_number(node) "Expected a node with a literal number, got $(kind(node))"
     if !_is_const_declaration(node) && !_in_array_assignment(node) && _is_magic_number(node)
         n = get_number(node)
-        if haskey(this.seen_before, n)
-            first_seen_line = this.seen_before[n]
-            current_line, _ = source_location(node)
-            extra_msg = first_seen_line == current_line ? "earlier on the same line" : "at line $first_seen_line"
+        if !haskey(this.number_occurrence, n)
+            this.number_occurrence[n] = Vector{SyntaxNode}()
+        end
+        push!(this.number_occurrence[n], node)
+        if length(this.number_occurrence[n]) > 1
+            first_instance_line, _ = source_location(first(this.number_occurrence[n]))
+            current_instance_line, _ = source_location(node)
+            extra_msg = first_instance_line == current_instance_line ? "earlier on the same line" : "at line $first_instance_line"
             report_violation(ctxt, this, node, "Hard-coded number '$n' (first used $extra_msg) should be a const variable.")
-        else
-            first_seen_line, _ = source_location(node)
-            this.seen_before[n] = first_seen_line
         end
     end
     return nothing

--- a/checks/AvoidHardCodedNumbers.jl
+++ b/checks/AvoidHardCodedNumbers.jl
@@ -31,11 +31,11 @@ const KNOWN_FLOATS = Set{Float64}([0.1, 0.01, 0.001, 0.0001, 0.5]) ∪
                     Set{Float64}(convert.(Float64, SOME_SPECIAL_INTS))
 
 struct Check<:Analysis.Check
-    seen_before::Set{Number}
+    seen_before::Dict{Number, Integer}
 
     # FIXME Fine for integers but, for floats, we should
     # probably use a tolerance to compare them.
-    Check() = new(Set{Number}())
+    Check() = new(Dict{Number, Integer}())
 end
 Analysis.id(::Check) = "avoid-hard-coded-numbers"
 Analysis.severity(::Check) = 3
@@ -51,10 +51,14 @@ function _check(this::Check, ctxt::AnalysisContext, node::SyntaxNode)::Nothing
     @assert is_literal_number(node) "Expected a node with a literal number, got $(kind(node))"
     if !_is_const_declaration(node) && !_in_array_assignment(node) && _is_magic_number(node)
         n = get_number(node)
-        if n ∈ this.seen_before
-            report_violation(ctxt, this, node, "Hard-coded number '$n' should be a const variable.")
+        if haskey(this.seen_before, n)
+            previous_line = this.seen_before[n]
+            current_line, _ = source_location(node)
+            extra_msg = previous_line == current_line ? "earlier on the same line" : "at line $previous_line"
+            report_violation(ctxt, this, node, "Hard-coded number '$n' (first used $extra_msg) should be a const variable.")
         else
-            push!(this.seen_before, n)
+            line, _ = source_location(node)
+            this.seen_before[n] = line
         end
     end
     return nothing

--- a/test/res/AvoidHardCodedNumbers.jl
+++ b/test/res/AvoidHardCodedNumbers.jl
@@ -1,3 +1,12 @@
+module GoodStyleFirstRound
+
+# Check that if a first mention of a number literal is in an allowed context,
+# the line number refers to the first faulty mention
+
+allowed_usage_in_array = [37.940, 37.941, 37.942]
+
+end #GoodStyleFirstRound
+
 module BadStyle
 
 energy = m * 4.493_775_893_684_088e16
@@ -19,6 +28,9 @@ wraparound_overflow_19_neg = 8446744073709551616
 wraparound_overflow_20_neg = -7766279631452241920
 
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
+
+first_wrong_usage = 37.940
+
 end # BadStyle
 
 module GoodStyle
@@ -57,5 +69,8 @@ another_vectorwraparound_overflow_19 = -8446744073709551616
 another_vectorwraparound_overflow_20 = 7766279631452241920
 another_vectorwraparound_overflow_19_neg = -7766279631452241920
 another_vectorwraparound_overflow_20_neg = 8446744073709551616
+
+# Should report on the line number of first_wrong_usage, not allowed_usage_in_array
+second_wrong_usage = 37.940
 
 end # BadStyle2ndRound

--- a/test/res/AvoidHardCodedNumbers.val
+++ b/test/res/AvoidHardCodedNumbers.val
@@ -1,79 +1,85 @@
 >> Processing file 'AvoidHardCodedNumbers.jl'...
 
-AvoidHardCodedNumbers.jl(21, 23):
+AvoidHardCodedNumbers.jl(30, 23):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
 #                     └─┘ ── Hard-coded number '1.1' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(21, 33):
+AvoidHardCodedNumbers.jl(30, 33):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
 #                               └─┘ ── Hard-coded number '1.1' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(21, 46):
+AvoidHardCodedNumbers.jl(30, 46):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
 #                                            └─┘ ── Hard-coded number '1.1' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(21, 51):
+AvoidHardCodedNumbers.jl(30, 51):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
 #                                                 └─┘ ── Hard-coded number '0.2' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(21, 56):
+AvoidHardCodedNumbers.jl(30, 56):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
 #                                                      └─┘ ── Hard-coded number '0.2' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(21, 61):
+AvoidHardCodedNumbers.jl(30, 61):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
 #                                                           └────┘ ── Hard-coded number '1000.1' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(44, 17):
+AvoidHardCodedNumbers.jl(56, 17):
 energy(m) = m * 4.493775893684088e16
-#               └──────────────────┘ ── Hard-coded number '4.493775893684088e16' (first used at line 3) should be a const variable.
+#               └──────────────────┘ ── Hard-coded number '4.493775893684088e16' (first used at line 12) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(45, 11):
+AvoidHardCodedNumbers.jl(57, 11):
 Area(r) = 3.14 * r ^ 2
-#         └──┘ ── Hard-coded number '3.14' (first used at line 4) should be a const variable.
+#         └──┘ ── Hard-coded number '3.14' (first used at line 13) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(52, 20):
+AvoidHardCodedNumbers.jl(64, 20):
 universal_answer = 42
-#                  └┘ ── Hard-coded number '42' (first used at line 12) should be a const variable.
+#                  └┘ ── Hard-coded number '42' (first used at line 21) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(56, 40):
+AvoidHardCodedNumbers.jl(68, 40):
 another_vectorwraparound_overflow_19 = -8446744073709551616
-#                                      └──────────────────┘ ── Hard-coded number '-8446744073709551616' (first used at line 16) should be a const variable.
+#                                      └──────────────────┘ ── Hard-coded number '-8446744073709551616' (first used at line 25) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(57, 40):
+AvoidHardCodedNumbers.jl(69, 40):
 another_vectorwraparound_overflow_20 = 7766279631452241920
-#                                      └─────────────────┘ ── Hard-coded number '7766279631452241920' (first used at line 17) should be a const variable.
+#                                      └─────────────────┘ ── Hard-coded number '7766279631452241920' (first used at line 26) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(58, 44):
+AvoidHardCodedNumbers.jl(70, 44):
 another_vectorwraparound_overflow_19_neg = -7766279631452241920
-#                                          └──────────────────┘ ── Hard-coded number '-7766279631452241920' (first used at line 19) should be a const variable.
+#                                          └──────────────────┘ ── Hard-coded number '-7766279631452241920' (first used at line 28) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
-AvoidHardCodedNumbers.jl(59, 44):
+AvoidHardCodedNumbers.jl(71, 44):
 another_vectorwraparound_overflow_20_neg = 8446744073709551616
-#                                          └─────────────────┘ ── Hard-coded number '8446744073709551616' (first used at line 18) should be a const variable.
+#                                          └─────────────────┘ ── Hard-coded number '8446744073709551616' (first used at line 27) should be a const variable.
+Avoid hard-coded numbers.
+Rule: avoid-hard-coded-numbers. Severity: 3
+
+AvoidHardCodedNumbers.jl(74, 22):
+second_wrong_usage = 37.940
+#                    └────┘ ── Hard-coded number '37.94' (first used at line 32) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3

--- a/test/res/AvoidHardCodedNumbers.val
+++ b/test/res/AvoidHardCodedNumbers.val
@@ -2,78 +2,78 @@
 
 AvoidHardCodedNumbers.jl(21, 23):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
-#                     └─┘ ── Hard-coded number '1.1' should be a const variable.
+#                     └─┘ ── Hard-coded number '1.1' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(21, 33):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
-#                               └─┘ ── Hard-coded number '1.1' should be a const variable.
+#                               └─┘ ── Hard-coded number '1.1' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(21, 46):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
-#                                            └─┘ ── Hard-coded number '1.1' should be a const variable.
+#                                            └─┘ ── Hard-coded number '1.1' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(21, 51):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
-#                                                 └─┘ ── Hard-coded number '0.2' should be a const variable.
+#                                                 └─┘ ── Hard-coded number '0.2' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(21, 56):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
-#                                                      └─┘ ── Hard-coded number '0.2' should be a const variable.
+#                                                      └─┘ ── Hard-coded number '0.2' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(21, 61):
 nok_floats = max(1.1, 1.1, 0.2, 1.1, 1000.1, 1.1, 0.2, 0.2, 1000.1)
-#                                                           └────┘ ── Hard-coded number '1000.1' should be a const variable.
+#                                                           └────┘ ── Hard-coded number '1000.1' (first used earlier on the same line) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(44, 17):
 energy(m) = m * 4.493775893684088e16
-#               └──────────────────┘ ── Hard-coded number '4.493775893684088e16' should be a const variable.
+#               └──────────────────┘ ── Hard-coded number '4.493775893684088e16' (first used at line 3) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(45, 11):
 Area(r) = 3.14 * r ^ 2
-#         └──┘ ── Hard-coded number '3.14' should be a const variable.
+#         └──┘ ── Hard-coded number '3.14' (first used at line 4) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(52, 20):
 universal_answer = 42
-#                  └┘ ── Hard-coded number '42' should be a const variable.
+#                  └┘ ── Hard-coded number '42' (first used at line 12) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(56, 40):
 another_vectorwraparound_overflow_19 = -8446744073709551616
-#                                      └──────────────────┘ ── Hard-coded number '-8446744073709551616' should be a const variable.
+#                                      └──────────────────┘ ── Hard-coded number '-8446744073709551616' (first used at line 16) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(57, 40):
 another_vectorwraparound_overflow_20 = 7766279631452241920
-#                                      └─────────────────┘ ── Hard-coded number '7766279631452241920' should be a const variable.
+#                                      └─────────────────┘ ── Hard-coded number '7766279631452241920' (first used at line 17) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(58, 44):
 another_vectorwraparound_overflow_19_neg = -7766279631452241920
-#                                          └──────────────────┘ ── Hard-coded number '-7766279631452241920' should be a const variable.
+#                                          └──────────────────┘ ── Hard-coded number '-7766279631452241920' (first used at line 19) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(59, 44):
 another_vectorwraparound_overflow_20_neg = 8446744073709551616
-#                                          └─────────────────┘ ── Hard-coded number '8446744073709551616' should be a const variable.
+#                                          └─────────────────┘ ── Hard-coded number '8446744073709551616' (first used at line 18) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3

--- a/test/res/AvoidHardCodedNumbers.val
+++ b/test/res/AvoidHardCodedNumbers.val
@@ -80,6 +80,6 @@ Rule: avoid-hard-coded-numbers. Severity: 3
 
 AvoidHardCodedNumbers.jl(74, 22):
 second_wrong_usage = 37.940
-#                    └────┘ ── Hard-coded number '37.94' (first used at line 32) should be a const variable.
+#                    └────┘ ── Hard-coded number '37.940' (first used at line 32) should be a const variable.
 Avoid hard-coded numbers.
 Rule: avoid-hard-coded-numbers. Severity: 3


### PR DESCRIPTION
Conform the specification in the ticket [RM-37940](https://redmine.tiobe.com/issues/37940):

> Add first occurrence location to message, do not report on first occurrence

The first occurrence of a magic number was already skipped over, so this required no changes.

The location of the first occurrence has been added to the message. The message is dependent on whether the location of the first occurrence was on the same line or on a different line, as pointing to a line number if it's on the same line would potentially confuse.

* In the case of the same line, the message points to 'first used earlier in the same line'
* In the case of a different line, the message points to the specific line being used.

Also added a test checking for the behaviour where the first instance of a magic number is in an allowed context (eg. an array initialization) but is then used 2 more times in contexts where a magic number is not allowed. In that case the line referral should point to the first instances where it is used in a context where it is not allowed.