### PR TITLE
RM-37943: One line ending violation per file

### DIFF
--- a/checks/AvoidExtraneousWhitespaceBetweenOpenAndCloseCharacters.jl
+++ b/checks/AvoidExtraneousWhitespaceBetweenOpenAndCloseCharacters.jl
@@ -1,7 +1,7 @@
 module AvoidExtraneousWhitespaceBetweenOpenAndCloseCharacters
 
 using JuliaSyntax: SourceFile, has_flags, head, PARENS_FLAG, is_prefix_call
-using ...Properties: is_toplevel
+using ...Properties: is_root_node
 
 include("_common.jl")
 
@@ -114,7 +114,7 @@ function _check(this::Check, ctxt::AnalysisContext, sf::SourceFile)::Nothing
 end
 
 function Analysis.init(this::Check, ctxt::AnalysisContext)::Nothing
-    register_syntaxnode_action(ctxt, is_toplevel, root -> _check(this, ctxt, root.source))
+    register_syntaxnode_action(ctxt, is_root_node, root -> _check(this, ctxt, root.source))
     return nothing
 end
 

--- a/checks/ConsistentLineEndings.jl
+++ b/checks/ConsistentLineEndings.jl
@@ -1,7 +1,7 @@
 module ConsistentLineEndings
 
 using JuliaSyntax: SourceFile, JuliaSyntax as JS
-using ...Properties: is_toplevel
+using ...Properties: is_root_node
 
 include("_common.jl")
 
@@ -12,7 +12,7 @@ Analysis.synopsis(::Check) = "Make sure that the line endings are consistent wit
 
 
 function Analysis.init(this::Check, ctxt::AnalysisContext)::Nothing
-    register_syntaxnode_action(ctxt, is_toplevel, n -> _check(this, ctxt, n))
+    register_syntaxnode_action(ctxt, is_root_node, n -> _check(this, ctxt, n))
     return nothing
 end
 

--- a/checks/DoNotNestMultilineComments.jl
+++ b/checks/DoNotNestMultilineComments.jl
@@ -1,6 +1,6 @@
 module DoNotNestMultilineComments
 
-using ...Properties: is_toplevel
+using ...Properties: is_root_node
 using ...SyntaxNodeHelpers
 
 include("_common.jl")
@@ -14,7 +14,7 @@ Analysis.severity(::Check) = 9
 Analysis.synopsis(::Check) = "Don't nest multiline comments"
 
 function Analysis.init(this::Check, ctxt::AnalysisContext)::Nothing
-    register_syntaxnode_action(ctxt, is_toplevel, node -> begin
+    register_syntaxnode_action(ctxt, is_root_node, node -> begin
         code = node.source.code
         comments = filter(gl -> kind(gl) == K"Comment", ctxt.greenleaves)
         for comment in comments

--- a/checks/IndentationLevelsAreFourSpaces.jl
+++ b/checks/IndentationLevelsAreFourSpaces.jl
@@ -1,6 +1,6 @@
 module IndentationLevelsAreFourSpaces
 
-using ...Properties: is_toplevel
+using ...Properties: is_root_node
 
 include("_common.jl")
 
@@ -10,7 +10,7 @@ Analysis.severity(::Check) = 7
 Analysis.synopsis(::Check) = "Indentation should be a multiple of four spaces"
 
 function Analysis.init(this::Check, ctxt::AnalysisContext)::Nothing
-    register_syntaxnode_action(ctxt, is_toplevel, n -> begin
+    register_syntaxnode_action(ctxt, is_root_node, n -> begin
         for gl in ctxt.greenleaves
             # We will inspect nodes of kind [NewlineWs] containing indentation spaces
             # and possibly (most of the time, in fact) starting with a line break, but

--- a/checks/ModuleEndComment.jl
+++ b/checks/ModuleEndComment.jl
@@ -3,7 +3,7 @@ module ModuleEndComment
 include("_common.jl")
 
 using JuliaSyntax: last_byte
-using ...Properties: is_module, is_toplevel, get_module_name
+using ...Properties: is_module, get_module_name
 
 struct Check<:Analysis.Check end
 Analysis.id(::Check) = "module-end-comment"

--- a/checks/NewlineAtFileEnd.jl
+++ b/checks/NewlineAtFileEnd.jl
@@ -1,7 +1,7 @@
 module NewlineAtFileEnd
 
 using JuliaSyntax
-using ...Properties: is_toplevel
+using ...Properties: is_highest_toplevel
 using ...WhitespaceHelpers: get_line_range
 
 include("_common.jl")
@@ -12,7 +12,7 @@ Analysis.severity(::Check) = 7
 Analysis.synopsis(::Check) = "Single newline at the end of file"
 
 function Analysis.init(this::Check, ctxt::AnalysisContext)::Nothing
-    register_syntaxnode_action(ctxt, is_toplevel, n -> _check(this, ctxt, n))
+    register_syntaxnode_action(ctxt, is_highest_toplevel, n -> _check(this, ctxt, n))
     return nothing
 end
 

--- a/checks/NewlineAtFileEnd.jl
+++ b/checks/NewlineAtFileEnd.jl
@@ -1,7 +1,7 @@
 module NewlineAtFileEnd
 
 using JuliaSyntax
-using ...Properties: is_highest_toplevel
+using ...Properties: is_root_node
 using ...WhitespaceHelpers: get_line_range
 
 include("_common.jl")
@@ -12,7 +12,7 @@ Analysis.severity(::Check) = 7
 Analysis.synopsis(::Check) = "Single newline at the end of file"
 
 function Analysis.init(this::Check, ctxt::AnalysisContext)::Nothing
-    register_syntaxnode_action(ctxt, is_highest_toplevel, n -> _check(this, ctxt, n))
+    register_syntaxnode_action(ctxt, is_root_node, n -> _check(this, ctxt, n))
     return nothing
 end
 

--- a/checks/OmitTrailingWhiteSpace.jl
+++ b/checks/OmitTrailingWhiteSpace.jl
@@ -1,6 +1,6 @@
 module OmitTrailingWhiteSpace
 
-using ...Properties: is_toplevel
+using ...Properties: is_root_node
 
 include("_common.jl")
 
@@ -10,7 +10,7 @@ Analysis.severity(::Check) = 7
 Analysis.synopsis(::Check) = "Omit spaces at the end of a line"
 
 function Analysis.init(this::Check, ctxt::AnalysisContext)::Nothing
-    register_syntaxnode_action(ctxt, is_toplevel, n -> _check(this, ctxt, n))
+    register_syntaxnode_action(ctxt, is_root_node, n -> _check(this, ctxt, n))
     return nothing
 end
 
@@ -26,4 +26,3 @@ function _check(this::Check, ctxt::AnalysisContext, node::SyntaxNode)::Nothing
 end
 
 end # module OmitTrailingWhiteSpace
-

--- a/checks/SingleSpaceAfterCommasAndSemicolons.jl
+++ b/checks/SingleSpaceAfterCommasAndSemicolons.jl
@@ -2,7 +2,7 @@ module SingleSpaceAfterCommasAndSemicolons
 
 include("_common.jl")
 
-using ...Properties: is_toplevel
+using ...Properties: is_root_node
 using ...SyntaxNodeHelpers
 
 struct Check<:Analysis.Check end
@@ -11,7 +11,7 @@ Analysis.severity(::Check) = 7
 Analysis.synopsis(::Check) = "Commas and semicolons are followed, but not preceded, by a space."
 
 function Analysis.init(this::Check, ctxt::AnalysisContext)::Nothing
-    register_syntaxnode_action(ctxt, is_toplevel, node -> begin
+    register_syntaxnode_action(ctxt, is_root_node, node -> begin
         code = node.source.code
         report_if_space(pos::Integer, func::Function, shouldhave::Integer, msg::String)::Nothing = begin
             range = func(code, pos)

--- a/src/Properties.jl
+++ b/src/Properties.jl
@@ -91,7 +91,7 @@ is_stop_point(node::AnyTree)::Bool =
     kind(node) ∈ KSet"function module do let toplevel macro"
 
 function is_root_node(node::AnyTree)::Bool
-    return is_toplevel(node) && isnothing(node.parent)
+    return isnothing(node.parent)
 end
 
 function is_eval_call(node::AnyTree)::Bool

--- a/src/Properties.jl
+++ b/src/Properties.jl
@@ -17,9 +17,9 @@ export AnyTree, NullableNode, MAX_LINE_LENGTH,
 
     haschildren, increase_counters, is_abstract, is_array_assignment, is_array_indx, is_assignment,
     is_broadcasting_assignment, is_constant, is_dot, is_eq_neq_comparison, is_eval_call, is_export,
-    is_fat_snake_case, is_field_assignment, is_flow_cntrl, is_function, is_global_decl, is_highest_toplevel,
+    is_fat_snake_case, is_field_assignment, is_flow_cntrl, is_function, is_global_decl,
     is_import, is_include, is_infix_operator, is_literal_number, is_loop, is_lower_snake, is_macro,
-    is_module, is_mutating_call, is_operator, is_range, is_separator, is_stop_point,
+    is_module, is_mutating_call, is_operator, is_range, is_root_node, is_separator, is_stop_point,
     is_struct, is_toplevel, is_type_op, is_union_decl, is_upper_camel_case, is_vect,
     is_call, is_mod_toplevel, inside,
 
@@ -90,7 +90,7 @@ is_array_assignment(n::SyntaxNode)::Bool = is_array_indx(n) && is_assignment(n.p
 is_stop_point(node::AnyTree)::Bool =
     kind(node) ∈ KSet"function module do let toplevel macro"
 
-function is_highest_toplevel(node::AnyTree)::Bool
+function is_root_node(node::AnyTree)::Bool
     return is_toplevel(node) && isnothing(node.parent)
 end
 

--- a/src/Properties.jl
+++ b/src/Properties.jl
@@ -17,7 +17,7 @@ export AnyTree, NullableNode, MAX_LINE_LENGTH,
 
     haschildren, increase_counters, is_abstract, is_array_assignment, is_array_indx, is_assignment,
     is_broadcasting_assignment, is_constant, is_dot, is_eq_neq_comparison, is_eval_call, is_export,
-    is_fat_snake_case, is_field_assignment, is_flow_cntrl, is_function, is_global_decl,
+    is_fat_snake_case, is_field_assignment, is_flow_cntrl, is_function, is_global_decl, is_highest_toplevel,
     is_import, is_include, is_infix_operator, is_literal_number, is_loop, is_lower_snake, is_macro,
     is_module, is_mutating_call, is_operator, is_range, is_separator, is_stop_point,
     is_struct, is_toplevel, is_type_op, is_union_decl, is_upper_camel_case, is_vect,
@@ -89,6 +89,10 @@ is_array_assignment(n::SyntaxNode)::Bool = is_array_indx(n) && is_assignment(n.p
 # When searching for a parent node of a certain kind, we stop at these nodes:
 is_stop_point(node::AnyTree)::Bool =
     kind(node) ∈ KSet"function module do let toplevel macro"
+
+function is_highest_toplevel(node::AnyTree)::Bool
+    return is_toplevel(node) && isnothing(node.parent)
+end
 
 function is_eval_call(node::AnyTree)::Bool
     return kind(node) == K"macrocall" &&

--- a/test/res/NewlineAtFileEnd.jl/NewlineWithDoubleToplevel.jl
+++ b/test/res/NewlineAtFileEnd.jl/NewlineWithDoubleToplevel.jl
@@ -1,0 +1,7 @@
+Base.@kwdef mutable struct Location
+    x::Symbol = :x
+    y::Symbol = :y
+end
+
+# something here which triggers a new toplevel
+const LOCATION = Location();

--- a/test/res/NewlineAtFileEnd.jl/NewlineWithDoubleToplevel.val
+++ b/test/res/NewlineAtFileEnd.jl/NewlineWithDoubleToplevel.val
@@ -1,0 +1,7 @@
+>> Processing file 'NewlineAtFileEnd.jl/NewlineWithDoubleToplevel.jl'...
+
+NewlineAtFileEnd.jl\NewlineAtFileEnd_no_nl.jl(8, 0):
+const LOCATION = Location();
+└──────────────────────────┘ ── No newline found at end of file.
+Single newline at the end of file.
+Rule: newline-at-file-end. Severity: 7

--- a/test/res/NewlineAtFileEnd.jl/NewlineWithDoubleToplevel.val
+++ b/test/res/NewlineAtFileEnd.jl/NewlineWithDoubleToplevel.val
@@ -1,6 +1,6 @@
 >> Processing file 'NewlineAtFileEnd.jl/NewlineWithDoubleToplevel.jl'...
 
-NewlineAtFileEnd.jl\NewlineAtFileEnd_no_nl.jl(8, 0):
+NewlineAtFileEnd.jl\NewlineWithDoubleToplevel.jl(7, 0):
 const LOCATION = Location();
 └──────────────────────────┘ ── No newline found at end of file.
 Single newline at the end of file.


### PR DESCRIPTION
This issue has been fixed by addressing the fact that a Julia file might contain multiple statements of kind ```toplevel```. Instead, we now ensure that such a rule is only triggered once, by replacing the ```is_toplevel``` statement with ```is_root_node``` - which checks whether a node is a toplevel node without a parent.

While reproducing this issue, JuliaCheck immediately also falsely triggered two times on ```single-space-after-commas-and-semicolons```. This rule also triggered on the toplevel predicate, like ```newline-at-file-end``` did.

As such, it made sense to me to replace this in all rules where we used ```is_toplevel``` to look for the root node. This should ensure that we run these rules only once, rather than mistakenly triggering on any toplevel.

Added a new test that reproduces this issue in the before-situation.

Unrelated change: While looking for instances of ```is_toplevel```, I also found that ModuleEndComment imported it without using it, so that one has been removed.

