### PR TITLE
RM-37942: Global placement false positive

### DIFF
--- a/checks/LocationOfGlobalVariables.jl
+++ b/checks/LocationOfGlobalVariables.jl
@@ -2,7 +2,8 @@ module LocationOfGlobalVariables
 
 include("_common.jl")
 
-using ...Properties: haschildren, is_export, is_global_decl, is_import, is_mod_toplevel
+using ...Properties: haschildren, is_export, is_global_decl, is_import, is_mod_toplevel,
+                     is_triple_quote
 
 struct Check<:Analysis.Check end
 Analysis.id(::Check) = "location-of-global-variables"
@@ -28,15 +29,27 @@ function _check(this::Check, ctxt::AnalysisContext, glob_decl::SyntaxNode)::Noth
         if node === glob_decl
             return # we are done
         end
-        if ! (is_import(node) || is_export(node) || is_global_decl(node))
-            # If we find a node that is not an import, export or global
-            # declaration between the start of the module and the global
-            # declaration under study, we report a violation.
-            report_violation(ctxt, this, glob_decl, synopsis(this))
-            return
+        if _is_allowed_before_const(node)
+            continue
         end
+        # Docstring constructions depend on whether the second child node is in the 'allowed list'.
+        # First child is the docstring. Second child is the node we need to check.
+        if kind(node) == K"doc"
+            commented_node = children(node)[2]
+            if _is_allowed_before_const(commented_node)
+                continue
+            end
+        end
+        report_violation(ctxt, this, glob_decl, synopsis(this))
     end
     return nothing
+end
+
+# Imports, exports, (other) global declarations and triple-quote comments are allowed
+# to be present before global declarations. Regular #-prefixed comments do not show
+# up in the syntax tree; they are only present in the green tree.
+function _is_allowed_before_const(node::SyntaxNode)::Bool
+    return is_import(node) || is_export(node) || is_global_decl(node) || is_triple_quote(node)
 end
 
 end # LocationOfGlobalVariables

--- a/checks/LocationOfGlobalVariables.jl
+++ b/checks/LocationOfGlobalVariables.jl
@@ -2,8 +2,7 @@ module LocationOfGlobalVariables
 
 include("_common.jl")
 
-using ...Properties: haschildren, is_export, is_global_decl, is_import, is_mod_toplevel,
-                     is_triple_quote
+using ...Properties: haschildren, is_export, is_global_decl, is_import, is_mod_toplevel
 
 struct Check<:Analysis.Check end
 Analysis.id(::Check) = "location-of-global-variables"
@@ -45,11 +44,10 @@ function _check(this::Check, ctxt::AnalysisContext, glob_decl::SyntaxNode)::Noth
     return nothing
 end
 
-# Imports, exports, (other) global declarations and triple-quote comments are allowed
-# to be present before global declarations. Regular #-prefixed comments do not show
-# up in the syntax tree; they are only present in the green tree.
+# Imports, exports, (other) global declarations are allowed
+# to be present before global declarations.
 function _is_allowed_before_const(node::SyntaxNode)::Bool
-    return is_import(node) || is_export(node) || is_global_decl(node) || is_triple_quote(node)
+    return is_import(node) || is_export(node) || is_global_decl(node)
 end
 
 end # LocationOfGlobalVariables

--- a/src/Properties.jl
+++ b/src/Properties.jl
@@ -1,7 +1,7 @@
 module Properties
 
-import JuliaSyntax: Kind, GreenNode, SyntaxNode, SourceFile, @K_str, @KSet_str,
-    head, is_dotted, is_leaf, kind, numchildren, sourcetext, span, untokenize, JuliaSyntax as JS
+import JuliaSyntax: Kind, GreenNode, SyntaxNode, SourceFile, @K_str, @KSet_str, TRIPLE_STRING_FLAG,
+    has_flags, head, is_dotted, is_leaf, kind, numchildren, sourcetext, span, untokenize, JuliaSyntax as JS
 
 export AnyTree, NullableNode, MAX_LINE_LENGTH,
 
@@ -20,7 +20,7 @@ export AnyTree, NullableNode, MAX_LINE_LENGTH,
     is_fat_snake_case, is_field_assignment, is_flow_cntrl, is_function, is_global_decl,
     is_import, is_include, is_infix_operator, is_literal_number, is_loop, is_lower_snake, is_macro,
     is_module, is_mutating_call, is_operator, is_range, is_root_node, is_separator, is_stop_point,
-    is_struct, is_toplevel, is_type_op, is_union_decl, is_upper_camel_case, is_vect,
+    is_struct, is_toplevel, is_triple_quote, is_type_op, is_union_decl, is_upper_camel_case, is_vect,
     is_call, is_mod_toplevel, inside,
 
     lines_count, opens_scope,
@@ -77,6 +77,7 @@ is_array_indx(node::AnyTree)::Bool = kind(node) == K"ref"
 is_vect(node::AnyTree)::Bool = kind(node) == K"vect"
 is_call(node::AnyTree)::Bool = kind(node) == K"call"
 
+
 is_loop(node::AnyTree)::Bool = kind(node) in KSet"while for"
 is_separator(node::AnyTree)::Bool = kind(node) in KSet", ;"
 is_flow_cntrl(node::AnyTree)::Bool = kind(node) in KSet"if for while try"
@@ -114,6 +115,10 @@ function is_constant(node::AnyTree)::Bool
     return kind(node) == K"const" ||
             (kind(node) == K"global" && haschildren(node) &&
             kind(children(node)[1]) == K"const")
+end
+
+function is_triple_quote(node::AnyTree)::Bool
+    return kind(node) == K"string" && has_flags(node, TRIPLE_STRING_FLAG)
 end
 
 function is_union_decl(node::SyntaxNode)::Bool

--- a/src/Properties.jl
+++ b/src/Properties.jl
@@ -1,6 +1,6 @@
 module Properties
 
-import JuliaSyntax: Kind, GreenNode, SyntaxNode, SourceFile, @K_str, @KSet_str, TRIPLE_STRING_FLAG,
+import JuliaSyntax: Kind, GreenNode, SyntaxNode, SourceFile, @K_str, @KSet_str,
     has_flags, head, is_dotted, is_leaf, kind, numchildren, sourcetext, span, untokenize, JuliaSyntax as JS
 
 export AnyTree, NullableNode, MAX_LINE_LENGTH,
@@ -20,7 +20,7 @@ export AnyTree, NullableNode, MAX_LINE_LENGTH,
     is_fat_snake_case, is_field_assignment, is_flow_cntrl, is_function, is_global_decl,
     is_import, is_include, is_infix_operator, is_literal_number, is_loop, is_lower_snake, is_macro,
     is_module, is_mutating_call, is_operator, is_range, is_root_node, is_separator, is_stop_point,
-    is_struct, is_toplevel, is_triple_quote, is_type_op, is_union_decl, is_upper_camel_case, is_vect,
+    is_struct, is_toplevel, is_type_op, is_union_decl, is_upper_camel_case, is_vect,
     is_call, is_mod_toplevel, inside,
 
     lines_count, opens_scope,
@@ -115,10 +115,6 @@ function is_constant(node::AnyTree)::Bool
     return kind(node) == K"const" ||
             (kind(node) == K"global" && haschildren(node) &&
             kind(children(node)[1]) == K"const")
-end
-
-function is_triple_quote(node::AnyTree)::Bool
-    return kind(node) == K"string" && has_flags(node, TRIPLE_STRING_FLAG)
 end
 
 function is_union_decl(node::SyntaxNode)::Bool

--- a/src/Properties.jl
+++ b/src/Properties.jl
@@ -1,7 +1,7 @@
 module Properties
 
 import JuliaSyntax: Kind, GreenNode, SyntaxNode, SourceFile, @K_str, @KSet_str,
-    has_flags, head, is_dotted, is_leaf, kind, numchildren, sourcetext, span, untokenize, JuliaSyntax as JS
+    head, is_dotted, is_leaf, kind, numchildren, sourcetext, span, untokenize, JuliaSyntax as JS
 
 export AnyTree, NullableNode, MAX_LINE_LENGTH,
 
@@ -76,7 +76,6 @@ is_abstract(node::AnyTree)::Bool = kind(node) == K"abstract"
 is_array_indx(node::AnyTree)::Bool = kind(node) == K"ref"
 is_vect(node::AnyTree)::Bool = kind(node) == K"vect"
 is_call(node::AnyTree)::Bool = kind(node) == K"call"
-
 
 is_loop(node::AnyTree)::Bool = kind(node) in KSet"while for"
 is_separator(node::AnyTree)::Bool = kind(node) in KSet", ;"

--- a/test/res/LocationOfGlobalVariables.jl
+++ b/test/res/LocationOfGlobalVariables.jl
@@ -19,6 +19,22 @@ end # module MyBadStylePackage
 
 const SOME_GLOBAL = 0.7
 
+module AnotherBadStylePackage
+
+    using Statistics
+
+    """
+    This function is documented, and should still be treated as something that prevents
+    the const MY_GLOB to be considered 'at the top of the file'.
+    """
+    function foo()::Nothing
+        return nothing
+    end
+
+    const MY_GLOB = 42
+
+end # module MyBadStylePackage
+
 module MyGoodStylePackage
 
     using Statistics
@@ -36,11 +52,30 @@ module MyGoodStylePackage
     """
 
     const MY_GLOB = 42
+    
+    """
+    and neither is a docstring right in front of a global
+    """
+    const YES_ANOTHER_ONE = 43
+
+    const AND_ANOTHER = 44
 
     function foo()::Nothing
         return nothing
     end
 
 end # module MyGoodStylePackage
+
+module AnotherGoodStylePackage
+
+    using Statistics
+
+    # So, technically, this is another assignment, and as such should _not_ trigger
+    # the rule on both this assignment and the assignment after it.
+    string_assignment = """yes, this is a string assignment!"""
+
+    const YET_ANOTHER_THINGIE = 5
+
+end # module AnotherGoodStylePackage
 
 end # module module_include_location

--- a/test/res/LocationOfGlobalVariables.jl
+++ b/test/res/LocationOfGlobalVariables.jl
@@ -46,12 +46,6 @@ module MyGoodStylePackage
     import .SomeSubmodule
 
     # a comment is no problem
-
-    """
-    a long form comment is no problem either
-    """
-
-    const MY_GLOB = 42
     
     """
     and neither is a docstring right in front of a global

--- a/test/res/LocationOfGlobalVariables.jl
+++ b/test/res/LocationOfGlobalVariables.jl
@@ -29,6 +29,12 @@ module MyGoodStylePackage
     include("SomeSubmodule.jl")  # except `include` for a submodule
     import .SomeSubmodule
 
+    # a comment is no problem
+
+    """
+    a long form comment is no problem either
+    """
+
     const MY_GLOB = 42
 
     function foo()::Nothing

--- a/test/res/LocationOfGlobalVariables.val
+++ b/test/res/LocationOfGlobalVariables.val
@@ -1,4 +1,3 @@
-
 >> Processing file 'LocationOfGlobalVariables.jl'...
 
 LocationOfGlobalVariables.jl(16, 5):
@@ -10,5 +9,11 @@ Rule: location-of-global-variables. Severity: 7
 LocationOfGlobalVariables.jl(20, 1):
 const SOME_GLOBAL = 0.7
 └─────────────────────┘ ── Global variables should be placed at the top of a module or file.
+Global variables should be placed at the top of a module or file.
+Rule: location-of-global-variables. Severity: 7
+
+LocationOfGlobalVariables.jl(34, 5):
+    const MY_GLOB = 42
+#   └────────────────┘ ── Global variables should be placed at the top of a module or file.
 Global variables should be placed at the top of a module or file.
 Rule: location-of-global-variables. Severity: 7


### PR DESCRIPTION
This mistriggered on the triple-quote string comment before the global variable. The misconception here was that this triple-quote string would not be present in the AST as it should have been treated as a comment. It does however show up as a ```[string-s]``` node. Like regular comments, this is now allowed to be skipped over.

Also took into account the possibility of a docstring + constant pair. This seems to be a consequence of the way it's parsed by JuliaSyntax, where this is dependent on whether there is whitespace in between:

```
[string-s]
  "a long form comment is no problem either\n" :: String
[const]
  [=]
    MY_GLOB                    :: Identifier
    42                         :: Integer
```
is what it looks like if it has extra whitespace.

```
[doc]
  [string-s]
    "and neither is a docstring right in front of a global\n" :: String
  [const]
    [=]
      YES_ANOTHER_ONE          :: Identifier
      43                       :: Integer
```
is what it looks like if it's present without any whitespace.

This required a little extra effort. Taking the second child of a ```[doc]``` construction will allow us to still check for whether we're allowed to skip over the node. As a bonus, this also resolves any other false positives of this rule on documented constructions. None were in the bugtracker so far, but it seemed like a logical addition to this PR.