### PR TITLE
RM-37944: Fix false positive in do-not-comment-out-code for single identifiers

### DIFF
--- a/checks/DoNotCommentOutCode.jl
+++ b/checks/DoNotCommentOutCode.jl
@@ -17,7 +17,12 @@ const KEYWORDS = ["baremodule", "begin", "break", "const", "continue", "do", "ex
         "for", "function", "global", "if", "import", "let", "local", "macro", "module",
         "quote", "return", "struct", "try", "using", "while", "catch", "finally", "else",
         "elseif", "end", "abstract", "as", "doc", "mutable", "outer", "primitive", "public",
-        "type", "var", "(", ")"]
+        "type", "var"]
+
+const WORD_KEYWORD_REGEX = Regex("\\b(" * join(WORD_KEYWORDS, "|") * ")\\b")
+
+const SYMBOL_HINTS = ["(", ")", "[", "]", "{", "}", "=", "::", "->"]
+const SINGLE_IDENTIFIER_REGEX = r"^[A-Za-z_][A-Za-z0-9_]*$"
 
 struct Check<:Analysis.Check end
 Analysis.id(::Check) = "do-not-comment-out-code"
@@ -51,9 +56,15 @@ function _report(ctxt::AnalysisContext, this::Check, range::UnitRange)::Nothing
     return nothing
 end
 
-# If JuliaSyntax can parse the comment contents, it must be code
+""" Returns true only for comments that look code-like and can be parsed as Julia code. """
 function _contains_code(text::AbstractString)::Bool
-    if !any(occursin(text), KEYWORDS) return false end
+    if _is_single_identifier(text)
+        # A single identifier is valid Julia code, but should not be considered commented-out code
+        return false
+    end
+    if !_has_code_markers(text)
+        return false
+    end
     try
         parseall(SyntaxNode, text)
     catch
@@ -64,6 +75,14 @@ end
 
 function _contains_code(comment::CommentOrCommentBlock)::Bool
     return _contains_code(get_text(comment))
+end
+
+function _is_single_identifier(text::AbstractString)::Bool
+    return occursin(SINGLE_IDENTIFIER_REGEX, strip(text))
+end
+
+function _has_code_markers(text::AbstractString)::Bool
+    return occursin(WORD_KEYWORD_REGEX, text) || any(sym -> occursin(sym, text), SYMBOL_HINTS)
 end
 
 end # module DoNotCommentOutCode

--- a/checks/DoNotCommentOutCode.jl
+++ b/checks/DoNotCommentOutCode.jl
@@ -13,13 +13,13 @@ Some keywords and other signifiers that need to be in the string in order for it
 
 Based on [keywords from JuliaSyntax.jl](https://github.com/JuliaLang/JuliaSyntax.jl/blob/99e975a726a82994de3f8e961e6fa8d39aed0d37/src/julia/kinds.jl#L209)
 """
-const WORD_KEYWORDS = ["baremodule", "begin", "break", "const", "continue", "do", "export",
+const KEYWORDS = ["baremodule", "begin", "break", "const", "continue", "do", "export",
         "for", "function", "global", "if", "import", "let", "local", "macro", "module",
         "quote", "return", "struct", "try", "using", "while", "catch", "finally", "else",
         "elseif", "end", "abstract", "as", "doc", "mutable", "outer", "primitive", "public",
         "type", "var"]
 
-const WORD_KEYWORD_REGEX = Regex("\\b(" * join(WORD_KEYWORDS, "|") * ")\\b")
+const KEYWORD_REGEX = Regex("\\b(" * join(KEYWORDS, "|") * ")\\b")
 
 const SYMBOL_HINTS = ["(", ")", "[", "]", "{", "}", "=", "::", "->"]
 const SINGLE_IDENTIFIER_REGEX = r"^[A-Za-z_][A-Za-z0-9_]*$"
@@ -56,7 +56,9 @@ function _report(ctxt::AnalysisContext, this::Check, range::UnitRange)::Nothing
     return nothing
 end
 
-""" Returns true only for comments that look code-like and can be parsed as Julia code. """
+"""
+Returns true only for comments that look code-like and can be parsed as Julia code.
+"""
 function _contains_code(text::AbstractString)::Bool
     if _is_single_identifier(text)
         # A single identifier is valid Julia code, but should not be considered commented-out code
@@ -82,7 +84,7 @@ function _is_single_identifier(text::AbstractString)::Bool
 end
 
 function _has_code_markers(text::AbstractString)::Bool
-    return occursin(WORD_KEYWORD_REGEX, text) || any(sym -> occursin(sym, text), SYMBOL_HINTS)
+    return occursin(KEYWORD_REGEX, text) || any(sym -> occursin(sym, text), SYMBOL_HINTS)
 end
 
 end # module DoNotCommentOutCode

--- a/checks/DoNotCommentOutCode.jl
+++ b/checks/DoNotCommentOutCode.jl
@@ -13,7 +13,7 @@ Some keywords and other signifiers that need to be in the string in order for it
 
 Based on [keywords from JuliaSyntax.jl](https://github.com/JuliaLang/JuliaSyntax.jl/blob/99e975a726a82994de3f8e961e6fa8d39aed0d37/src/julia/kinds.jl#L209)
 """
-const KEYWORDS = ["baremodule", "begin", "break", "const", "continue", "do", "export",
+const WORD_KEYWORDS = ["baremodule", "begin", "break", "const", "continue", "do", "export",
         "for", "function", "global", "if", "import", "let", "local", "macro", "module",
         "quote", "return", "struct", "try", "using", "while", "catch", "finally", "else",
         "elseif", "end", "abstract", "as", "doc", "mutable", "outer", "primitive", "public",

--- a/test/res/DoNotCommentOutCode.jl
+++ b/test/res/DoNotCommentOutCode.jl
@@ -40,3 +40,16 @@ while index <= 10
     println("$index")
     index += 2
 end
+
+function fix_false_positives_for_single_identifiers_RM37944()
+
+    ## GeneralReadoutSettings
+    index = 3
+
+    ## continueIsAlsoAKeyword
+    index = 4
+
+    # do (once)
+    index = 5
+end
+


### PR DESCRIPTION
[RM-37944](https://redmine.tiobe.com/issues/37944): Customer complaints that the following line is seen as code: 

```
## GeneralReadoutSettings
```

The reason is that it contains the keyword `do`, and `_contains_code` does a simple substring match. We fix it by requiring standalone keyword matches (word boundaries) before parsing, instead of substring matches.

Also, it seems safe to skip single identifiers regardless of whether they contain a keyword.

(note: Copilot was used for implementing this PR)