### PR TITLE
RM-37946: Use case-insensitive ordering for list of packages in module-single-import-line

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 ArgParse = "1.2"

--- a/checks/ModuleSingleImportLine.jl
+++ b/checks/ModuleSingleImportLine.jl
@@ -3,6 +3,8 @@ module ModuleSingleImportLine
 include("_common.jl")
 using ...Properties: get_imported_pkg, is_import, is_include, is_module
 
+using Unicode
+
 struct Check<:Analysis.Check end
 Analysis.id(::Check) = "module-single-import-line"
 Analysis.severity(::Check) = 9
@@ -22,8 +24,12 @@ function _check(this::Check, ctxt::AnalysisContext, module_node::SyntaxNode)::No
     imports = filter(is_import, children(children(module_node)[2]))
 
     _check_multiple_imports_on_line(this, ctxt, imports)
-    _check_import_ordering(this, ctxt, imports)
-    _check_include_ordering(this, ctxt, imports)
+
+    # Check imports/usings
+    _check_ordering(this, ctxt, imports, node -> !is_include(node) && numchildren(node) <= 1)
+
+    # Check includes
+    _check_ordering(this, ctxt, imports, is_include)
     return nothing
 end
 
@@ -36,32 +42,22 @@ function _check_multiple_imports_on_line(this::Check, ctxt::AnalysisContext, imp
     return nothing
 end
 
-function _check_import_ordering(this::Check, ctxt::AnalysisContext, imports::Vector{SyntaxNode})::Nothing
-    previous = ""
-    for node in filter(!is_include, imports)
-        pkg_name = get_imported_pkg(node)
-        if numchildren(node) <= 1
-            if pkg_name < previous
-                report_violation(ctxt, this, node, synopsis(this))
-                return nothing
-            else
-                previous = pkg_name
-            end
-        end
-    end
-    return nothing
-end
 
-function _check_include_ordering(this::Check, ctxt::AnalysisContext, imports::Vector{SyntaxNode})::Nothing
+function _check_ordering(
+    this::Check,
+    ctxt::AnalysisContext,
+    imports::Vector{SyntaxNode},
+    predicate::Function
+)::Nothing
     previous = ""
-    for node in filter(is_include, imports)
-        pkg_name = get_imported_pkg(node)
-        if pkg_name < previous
+    for node in filter(predicate, imports)
+        pkg_name_normalized = Unicode.normalize(get_imported_pkg(node), casefold=true)
+        if pkg_name_normalized < previous
             report_violation(ctxt, this, node, synopsis(this))
             return nothing
-        else
-            previous = pkg_name
         end
+
+        previous = pkg_name_normalized
     end
     return nothing
 end

--- a/test/res/ModuleSingleImportLine.jl
+++ b/test/res/ModuleSingleImportLine.jl
@@ -11,9 +11,9 @@ end # module BadStyle
 module ReportOnlyOnceOnUsingOrdering
 
     using A
-    using D
+    import D
     using C
-    using B
+    import B
 
 end # module ReportOnlyOnceOnIncludeOrdering
 
@@ -44,10 +44,18 @@ module GoodStyle
 
     using JuliaSyntax: GreenNode, SyntaxNode, children
     using LinearAlgebra
-    using Random
-    using Statistics
+    using Metrology
+    using MLBase # RM-37946: test for case insensitive ordering
     using Test
 
 end # module GoodStyle
+
+module CaseInsensitiveOrderingForIncludes # RM-37946
+
+    include("JuliaA.jl")
+    include("JULIAB.jl")
+    include("JuliaC.jl")
+
+end # module GoodStyle2
 
 end # module_single_import_line


### PR DESCRIPTION
[RM-37946](https://redmine.tiobe.com/issues/37946): The following list of packages produces a false-positive:

``` julia
using MeterologyStructures
using MLBase
```

The reason is that strict lexical ordering is used. This is not expected.

Solution is to use `Unicode.normalize(str, casefold=true)` as suggested [here](https://stackoverflow.com/a/39401115/665780)

Also:
* Refactor the code a bit so that code duplication is reduced
