### PR TITLE
RM-38612: Remove export-ignore and eol from gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,32 +1,15 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
-# Check out val files with lf, actual output EOL will be converted in tests for Windows
-*.val text eol=lf
-
 # Fix syntax highlighting on GitHub to allow comments
 .vscode/*.json linguist-language=JSON-with-Comments
 
 # Julia
 *.jl linguist-language=Julia
 
-# Ensure line endings stay consistent for this test
-test/TestConsistentLineEndings.jl text eol=lf
-
 # Documents
 *.md       text diff=markdown
 *.txt      text
-
-# Scripts
-*.bash     text eol=lf
-*.fish     text eol=lf
-*.ksh      text eol=lf
-*.sh       text eol=lf
-*.zsh      text eol=lf
-# These are explicitly windows files and should use crlf
-*.bat      text eol=crlf
-*.cmd      text eol=crlf
-*.ps1      text eol=crlf
 
 # Serialisation
 *.json     text
@@ -34,10 +17,3 @@ test/TestConsistentLineEndings.jl text eol=lf
 *.xml      text
 *.yaml     text
 *.yml      text
-
-#
-# Exclude files from exporting
-#
-.gitattributes export-ignore
-.gitignore     export-ignore
-.gitkeep       export-ignore

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,7 @@
 name = "JuliaCheck"
 uuid = "7b5e9987-6321-4ad2-a98c-8fb2c158333b"
 version = "0.54.1"
-authors = [
-            "Anne Brouwers <anne.brouwers@tiobe.com>",
-            "Dennie Reniers <dennie.reniers@tiobe.com>",
-            "Paul van Zon <paul.van.zon@tiobe.com>",
-            "Juanma Bellon <juan.bellon@tiobe.com>"
-]
+authors = ["Anne Brouwers <anne.brouwers@tiobe.com>", "Dennie Reniers <dennie.reniers@tiobe.com>", "Paul van Zon <paul.van.zon@tiobe.com>", "Juanma Bellon <juan.bellon@tiobe.com>"]
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"


### PR DESCRIPTION
These caused a mismatch between the hash returned by `git rev-parse <sha>^{tree}` and the hash of the output of `git archive`, causing a [JuliaRegistry check](https://github.com/JuliaRegistries/General/blob/b92e504412ab43c8971eb53b30049878ec61db78/.ci/Treecheck/Treecheck.jl#L127) to fail.
